### PR TITLE
Allows the user to guess exact number of dice and earn a dice back.

### DIFF
--- a/src/cljs/liyarr/events.cljs
+++ b/src/cljs/liyarr/events.cljs
@@ -113,5 +113,6 @@
                            :on-failure [:firebase-error]}}
          {})))))
 
+(game-event! :exact-bid game/exact-bid)
 (game-event! :challenge-bid game/challenge-bid)
 (game-event! :initialize-round game/initialize-round)

--- a/src/cljs/liyarr/views.cljs
+++ b/src/cljs/liyarr/views.cljs
@@ -212,7 +212,15 @@
           {:class "button-primary"
            :disabled (listen :bidding?)
            :on-click #(rf/dispatch [:challenge-bid])}
-          "CHALLENGE!"]]])]))
+          "CHALLENGE!"]]
+        [:div
+         [:strong "... OR ..."]]
+        [:div
+         [:button
+          {:class "button-primary"
+           :disabled (listen :bidding?)
+           :on-click #(rf/dispatch [:exact-bid])}
+          "THE CURRENT BID IS CORRECT."]]])]))
 
 (defn current-player-display [{:keys [photo-url display-name dice]}
                               my-turn?
@@ -316,7 +324,8 @@
         players (listen :players)
         msg (listen :msg)
         action (listen :action)
-        challenged? (= action "challenge-bid")
+        challenged? (or (= action "challenge-bid")
+                        (= action "exact-bid"))
         action-result (listen :action-result)
         current-bid (listen :current-bid)
         current-player-idx (listen :current-player-idx)


### PR DESCRIPTION
This is a rule I've played with in the past, you can call calza (or jonti) if you think the last bid was the exact number of dice.

If you're wrong you lose a dice
If you're right and you don't have the max number of dice you get a dice back.

I added a button `The Current Bid is Correct` That will call calza.

It ends the round, satisfies the reward or punish, and starts a new round.